### PR TITLE
Added scoping to cust element template

### DIFF
--- a/templates/singleElement.js
+++ b/templates/singleElement.js
@@ -1,3 +1,4 @@
+(function(){
 /**
  * The template that is used for the shadow root for every copy of your element,
  * which houses the styles and layout for the element.
@@ -68,3 +69,4 @@ class /* {className} */ extends HTMLElement {
 }
 
 customElements.define("/* {tagName} */", /* {className} */);
+})();


### PR DESCRIPTION
Don't know why we didn't do this earlier. Naturally using two custom elements on the same page causes the global value `template` to get conflicts.